### PR TITLE
Funcion get_executor_partition_info() arreglada

### DIFF
--- a/jupyter/notebooks/spark/basics/01_spark_session.ipynb
+++ b/jupyter/notebooks/spark/basics/01_spark_session.ipynb
@@ -2,20 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
    "id": "92f7e43a-550e-4b11-8a42-57a2a022d950",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "24/10/13 17:43:49 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
-     ]
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T00:59:38.977161Z",
+     "start_time": "2024-10-15T00:59:31.137933Z"
     }
-   ],
+   },
    "source": [
     "# Spark Session\n",
     "from pyspark.sql import SparkSession\n",
@@ -26,20 +19,42 @@
     "    .appName(\"Spark Introduction\")\n",
     "    .config(\"spark.executor.instances\", \"2\")\n",
     "    .config(\"spark.executor.cores\", \"1\")\n",
-    "    .config(\"spark.executor.memory\", \"1g\") \n",
+    "    .config(\"spark.executor.memory\", \"1g\")\n",
     "    .master(\"spark://spark-master:7077\")\n",
     "    .getOrCreate()\n",
     ")"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
+      "24/10/15 00:59:35 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    }
+   ],
+   "execution_count": 1
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "id": "9d85b5ec-1e9f-4f03-80ca-029cf50a6518",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T00:59:54.623172Z",
+     "start_time": "2024-10-15T00:59:52.829941Z"
+    }
+   },
+   "source": [
+    "spark"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "<pyspark.sql.session.SparkSession at 0x7fffe80a9750>"
+      ],
       "text/html": [
        "\n",
        "            <div>\n",
@@ -48,7 +63,7 @@
        "        <div>\n",
        "            <p><b>SparkContext</b></p>\n",
        "\n",
-       "            <p><a href=\"http://7ed9d7ed5e4d:4040\">Spark UI</a></p>\n",
+       "            <p><a href=\"http://0c293ec01bbd:4040\">Spark UI</a></p>\n",
        "\n",
        "            <dl>\n",
        "              <dt>Version</dt>\n",
@@ -62,26 +77,24 @@
        "        \n",
        "            </div>\n",
        "        "
-      ],
-      "text/plain": [
-       "<pyspark.sql.session.SparkSession at 0x7f0cd225b090>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "spark"
-   ]
+   "execution_count": 3
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "id": "c0656d31-ba16-49f3-8f7f-f0c038d4d886",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T00:59:54.694006Z",
+     "start_time": "2024-10-15T00:59:54.687708Z"
+    }
+   },
    "source": [
     "# Emp Data & Schema\n",
     "\n",
@@ -109,26 +122,47 @@
     "]\n",
     "\n",
     "emp_schema = \"employee_id string, department_id string, name string, age string, gender string, salary string, hire_date string\""
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 4
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "id": "b1cd7a52-3086-43a9-8e64-dd87eee86c5a",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T00:59:59.477962Z",
+     "start_time": "2024-10-15T00:59:55.753580Z"
+    }
+   },
    "source": [
     "# Create emp DataFrame\n",
     "\n",
     "emp = spark.createDataFrame(data=emp_data, schema=emp_schema)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 5
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
    "id": "cb5c8a76-ab66-42b9-b885-475b7259c4f8",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T00:57:42.234339Z",
+     "start_time": "2024-10-15T00:57:36.136871Z"
+    }
+   },
+   "source": [
+    "emp.take(20)"
+   ],
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -154,20 +188,27 @@
        " Row(employee_id='020', department_id='102', name='Grace Kim', age='32', gender='Female', salary='53000', hire_date='2018-11-01')]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "emp.take(20)"
-   ]
+   "execution_count": 5
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
    "id": "9ea6550d-86fd-46fd-aeb1-e0ba7c8c84be",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T01:00:03.239901Z",
+     "start_time": "2024-10-15T01:00:01.737132Z"
+    }
+   },
+   "source": [
+    "# Check number of partitions\n",
+    "\n",
+    "emp.rdd.getNumPartitions()"
+   ],
    "outputs": [
     {
      "data": {
@@ -175,23 +216,36 @@
        "8"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "# Check number of partitions\n",
-    "\n",
-    "emp.rdd.getNumPartitions()"
-   ]
+   "execution_count": 6
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
    "id": "8ed4a06b-34e1-443e-ba41-fa2f04f336ad",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T01:00:09.112919Z",
+     "start_time": "2024-10-15T01:00:03.312315Z"
+    }
+   },
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "emp = emp.withColumn(\"partition_id\", F.spark_partition_id())\n",
+    "emp.show()"
+   ],
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 2:=======================================>                   (2 + 1) / 3]\r"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -222,36 +276,26 @@
       "+-----------+-------------+-------------+---+------+------+----------+------------+\n",
       "\n"
      ]
-    }
-   ],
-   "source": [
-    "from pyspark.sql import functions as F\n",
-    "\n",
-    "emp = emp.withColumn(\"partition_id\", F.spark_partition_id())\n",
-    "emp.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "058c1ba4-e2b8-4ff3-9d3e-5ed2d8169fcb",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Executor unknown is processing partition 0\n",
-      "Executor unknown is processing partition 1\n",
-      "Executor unknown is processing partition 2\n",
-      "Executor unknown is processing partition 3\n",
-      "Executor unknown is processing partition 4\n",
-      "Executor unknown is processing partition 5\n",
-      "Executor unknown is processing partition 6\n",
-      "Executor unknown is processing partition 7\n"
+      "                                                                                \r"
      ]
     }
    ],
+   "execution_count": 7
+  },
+  {
+   "cell_type": "code",
+   "id": "058c1ba4-e2b8-4ff3-9d3e-5ed2d8169fcb",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T01:00:16.544915Z",
+     "start_time": "2024-10-15T01:00:13.791158Z"
+    }
+   },
    "source": [
     "from pyspark import TaskContext\n",
     "import os\n",
@@ -261,35 +305,36 @@
     "    partition_id = context.partitionId()\n",
     "    executor_id = os.getenv(\"SPARK_EXECUTOR_ID\", \"unknown\")\n",
     "    \n",
-    "    # Return a string containing executor and partition information\n",
+    "    # Imprimir todas las variables de entorno para ver que SPARK_EXECUTOR_ID existe\n",
+    "    print(os.environ)\n",
+    "    \n",
     "    return [f\"Executor {executor_id} is processing partition {partition_id}\"]\n",
     "\n",
-    "# Apply the function and collect the results\n",
     "info = emp.rdd.mapPartitionsWithIndex(get_executor_partition_info).collect()\n",
     "\n",
-    "# Print the collected information on the driver\n",
     "for line in info:\n",
     "    print(line)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "ea3b0dfd-c9ab-49a8-9c72-1ebeb3450d73",
-   "metadata": {},
+   ],
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 3:============================================>              (6 + 2) / 8]\r"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Executor 7d01e3fcfccf is processing partition 0\n",
-      "Executor 57c92dd270c0 is processing partition 1\n",
-      "Executor 7d01e3fcfccf is processing partition 2\n",
-      "Executor 57c92dd270c0 is processing partition 3\n",
-      "Executor 7d01e3fcfccf is processing partition 4\n",
-      "Executor 57c92dd270c0 is processing partition 5\n",
-      "Executor 7d01e3fcfccf is processing partition 6\n",
-      "Executor 57c92dd270c0 is processing partition 7\n"
+      "Executor 8d4d02b01ea7 is processing partition 0\n",
+      "Executor 8d4d02b01ea7 is processing partition 1\n",
+      "Executor de04a8c09e98 is processing partition 2\n",
+      "Executor de04a8c09e98 is processing partition 3\n",
+      "Executor 8d4d02b01ea7 is processing partition 4\n",
+      "Executor de04a8c09e98 is processing partition 5\n",
+      "Executor de04a8c09e98 is processing partition 6\n",
+      "Executor 8d4d02b01ea7 is processing partition 7\n"
      ]
     },
     {
@@ -300,6 +345,17 @@
      ]
     }
    ],
+   "execution_count": 8
+  },
+  {
+   "cell_type": "code",
+   "id": "ea3b0dfd-c9ab-49a8-9c72-1ebeb3450d73",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-15T00:47:38.300199Z",
+     "start_time": "2024-10-15T00:47:36.838152Z"
+    }
+   },
    "source": [
     "import socket\n",
     "\n",
@@ -319,7 +375,38 @@
     "# Print the collected information on the driver\n",
     "for line in info:\n",
     "    print(line)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 7:======================>                                    (3 + 5) / 8]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executor 79fff4e7ee83 is processing partition 0\n",
+      "Executor e5ee7fdde0bb is processing partition 1\n",
+      "Executor e5ee7fdde0bb is processing partition 2\n",
+      "Executor 79fff4e7ee83 is processing partition 3\n",
+      "Executor 79fff4e7ee83 is processing partition 4\n",
+      "Executor e5ee7fdde0bb is processing partition 5\n",
+      "Executor e5ee7fdde0bb is processing partition 6\n",
+      "Executor 79fff4e7ee83 is processing partition 7\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "execution_count": 10
   },
   {
    "cell_type": "code",

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -46,6 +46,9 @@ ENV SPARK_LOG_DIR="/opt/spark/logs"
 ENV SPARK_MASTER_LOG="/opt/spark/logs/spark-master.out"
 ENV SPARK_WORKER_LOG="/opt/spark/logs/spark-worker.out"
 
+# Set SPARK_EXECUTOR_ID to the hostname
+RUN echo "export SPARK_EXECUTOR_ID=\$(hostname)" >> /opt/spark/conf/spark-env.sh
+
 USER root
 
 RUN chmod u+x /opt/spark/sbin/* && \


### PR DESCRIPTION
Añadida linea en Dockerfile de spark para exportar la variable de entorno y así poder obtenerla en jupyter
This pull request includes updates to the Spark session Jupyter notebook to improve logging and execution metadata tracking, as well as a minor change to the Spark Dockerfile to set the `SPARK_EXECUTOR_ID`.

### Jupyter Notebook Updates:
* Updated Spark UI link to reflect the new hostname. (`jupyter/notebooks/spark/basics/01_spark_session.ipynb`, [jupyter/notebooks/spark/basics/01_spark_session.ipynbL51-R66](diffhunk://#diff-2fb3212dfe63ccfff1f04fc0a999007768cfd6228b1a4ffcfedca32dc2dc8d45L51-R66))
* Added logging for environment variables to verify the presence of `SPARK_EXECUTOR_ID`. (`jupyter/notebooks/spark/basics/01_spark_session.ipynb`, [jupyter/notebooks/spark/basics/01_spark_session.ipynbL264-R337](diffhunk://#diff-2fb3212dfe63ccfff1f04fc0a999007768cfd6228b1a4ffcfedca32dc2dc8d45L264-R337))

### Dockerfile Update:
* Set `SPARK_EXECUTOR_ID` to the hostname in the Spark environment configuration. (`spark/Dockerfile`, [spark/DockerfileR49-R51](diffhunk://#diff-01b2c930d09e2fa7ca3452e9b903f2bd4235b84f3a6d02fe155012e82a860545R49-R51))